### PR TITLE
fix: Typos in zsh default prompt

### DIFF
--- a/.profile.d/common/common.zsh
+++ b/.profile.d/common/common.zsh
@@ -20,7 +20,7 @@ fi
 
 # Set a default prompt in case it is not overridden anywhere else
 # '<fg green>user@host<reset>:<fg red>pwd<reset>(#|$) '
-prompt='%F{green}%n@%m%f:%F{red}%-1~%f%(!.#.$)'
+prompt='%F{green}%n@%m%f:%F{red}%1~%f%(!.#.$) '
 
 # Load my shared aliases
 [[ -f ~/.aliases ]] && source ~/.aliases


### PR DESCRIPTION
- Show last part of cwd, not first
- Add a space after the prompt char