### PR TITLE
fix: Use standard Go path for consistency

### DIFF
--- a/.profile.d/golang/path.sh
+++ b/.profile.d/golang/path.sh
@@ -3,10 +3,8 @@
 #
 # Go path
 
-_LOCAL_GOPATH="$(local_lib_path go)"
-if [ -d "${_LOCAL_GOPATH}" ]; then
-    export GOPATH="${_LOCAL_GOPATH}${GOPATH:+":${GOPATH}"}"
-    export GOBIN="${_LOCAL_SDK}/bin"
-    export PATH="${_LOCAL_GOPATH}/bin${PATH:+":${PATH}"}"
+if [ -d "${HOME}/go" ]; then
+    export GOPATH="${HOME}/go${GOPATH:+":${GOPATH}"}"
+    export GOBIN="${HOME}/go/bin"
+    export PATH="${HOME}/go/bin${PATH:+":${PATH}"}"
 fi
-unset _LOCAL_GOPATH

--- a/.profile.d/golang/path.zsh
+++ b/.profile.d/golang/path.zsh
@@ -2,10 +2,8 @@
 #
 # Go path
 
-_LOCAL_SDK="$(local_lib_path go)"
-if [[ -d "${_LOCAL_SDK}" ]]; then
-    export GOPATH="${_LOCAL_SDK}${GOPATH:+":${GOPATH}"}"
-    export GOBIN="${_LOCAL_SDK}/bin"
-    path=(${_LOCAL_SDK}/bin $path)
+if [[ -d "${HOME}/go" ]]; then
+    export GOPATH="${HOME}/go${GOPATH:+":${GOPATH}"}"
+    export GOBIN="${HOME}/go/bin"
+    path=(${HOME}/go/bin $path)
 fi
-unset _LOCAL_SDK

--- a/bin/go_refresh.sh
+++ b/bin/go_refresh.sh
@@ -2,10 +2,8 @@
 #
 # Install common go packages to local library
 set -e
-# shellcheck disable=SC1090
-command -v local_lib_path >/dev/null 2>/dev/null || . ~/.profile.d/functions/local_lib_path
 
-_GOPATH="$(local_lib_path go)"
+_GOPATH="${HOME}/go"
 mkdir -p "${_GOPATH}"
 
 ECHO="$(which echo)" || "echo"


### PR DESCRIPTION
To ensure scripts and settings in containers and physical machines are compatible just use the standard GO path.