### PR TITLE
Add CA certificate bundles to system store

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/base:trixie AS ca-certs
+USER root
+COPY *pem /run/ca-certs/sources/
+
+# Split bundle(s) to individual crt (PEM) files
+RUN mkdir -p /run/ca-certs/extracts
+WORKDIR /run/ca-certs/extracts
+RUN openssl storeutl /run/ca-certs/sources/*pem | \
+    awk '/BEGIN CERTIFICATE/ { c++; } /BEGIN CERTIFICATE/,/END CERTIFICATE/ {print > c ".crt"}'
+
+FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm
+USER root
+COPY --from=ca-certs /run/ca-certs/extracts/*.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates -v

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,7 +5,7 @@
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/devcontainers/features/node:": {
+    "ghcr.io/devcontainers/features/node:2": {
       "version": "2.1.0",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
       "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
     "name": "memes-home",
-    "image": "mcr.microsoft.com/devcontainers/python:3.13-bookworm",
+    "dockerFile": "Dockerfile",
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/devcontainers/features/node:": {},
+        "ghcr.io/devcontainers/features/node:2": {},
         "ghcr.io/memes/devcontainers-features/direnv:1": {},
         "ghcr.io/memes/devcontainers-features/google-cloud-cli:1": {},
         "ghcr.io/memes/devcontainers-features/starship:1": {},

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ bin/vesctl
 !.devcontainer
 !.devcontainer/devcontainer.json
 !.devcontainer/devcontainer-lock.json
+!.devcontainer/Dockerfile
 !.vscode
 !.vscode/*json
 


### PR DESCRIPTION
If there are one or more CA certificate bundles in the .devcontainer folder they will be split into individual PEM files with .crt extension that can be copied into devcontainer and added to system CA store.

This repo's .devcontainer/Dockerfile is an example for Debian-based devcontainers.